### PR TITLE
Split PR CI from deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,8 +3,6 @@ name: Build and Deploy to Registry
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -40,7 +38,6 @@ jobs:
           images: ${{ env.REGISTRY_URL }}/${{ github.event.repository.name }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=sha,prefix={{branch}}-
             type=raw,value=latest,enable={{is_default_branch}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Inject Keyring secrets
+        uses: aidenappl/keyring-actions@v1
+        with:
+          url: ${{ secrets.KEYRING_URL }}
+          access-key-id: ${{ secrets.KEYRING_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.KEYRING_SECRET_ACCESS_KEY }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Add ci.yml as the PR quality gate; restrict deploy to push:[main] + workflow_dispatch and drop the PR image tag.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
